### PR TITLE
Read Drought Monitor data from AgReFed server

### DIFF
--- a/cdi.ipynb
+++ b/cdi.ipynb
@@ -40,7 +40,7 @@
    "source": [
     "## Getting started\n",
     "\n",
-    "Refresh the server to see changes in the CernVM-FS repository and then list all the files in the storage. We also need to load all modules needed for this notebook."
+    "We need to download a copy of the Drought Monitor dataset and save it locally. When running in the AgReFed container in the Nectar National Jupyterhub Service, a cache server is available. If running elsewhere, these URLs and paths will need to be adjusted accordingly. We can then list all the files in the local storage. We also need to load all Python modules needed for this notebook."
    ]
   },
   {
@@ -48,7 +48,7 @@
    "id": "a17499f6",
    "metadata": {},
    "source": [
-    "###  Refresh the server "
+    "###  Configure data source and storage"
    ]
   },
   {
@@ -58,8 +58,51 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Not connected to CVMFS at this time, so commenting this cell!\n",
-    "# !sudo cvmfs_config reload netcdftest.usq"
+    "import os\n",
+    "\n",
+    "# Base URL to the Drought Monitor dataset\n",
+    "# When running in the Nectar Jupyterhub service, pull drought_monitor data from AgReFed data cache:\n",
+    "url_of_drought_monitor_data = 'https://data.agrefed.org.au/drought_monitor/'\n",
+    "\n",
+    "# Path to local storage - approx 4 GB required\n",
+    "path_to_drought_monitor_data = os.path.join(os.sep, 'home', 'jovyan', 'drought_monitor_data')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a3ed7082-c0c8-4456-8dfc-39d8e7953821",
+   "metadata": {},
+   "source": [
+    "###  Download and cache the data"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "98655e50-6188-418c-aa5c-ffc97b79ec1b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import requests\n",
+    "\n",
+    "drought_monitor_data_files = ['cdi_1.nc', 'cdi_3.nc', 'cdi_6.nc', 'cdi_9.nc', 'cdi_12.nc', 'cdi_24.nc', 'cdi_36.nc']\n",
+    "\n",
+    "# Create the local storage directory\n",
+    "if not os.path.exists(path_to_drought_monitor_data):\n",
+    "    os.mkdir(path_to_drought_monitor_data)\n",
+    "\n",
+    "# utility function to download and save a file\n",
+    "def download_drought_monitor_data (url_base, filename, dest_dir):\n",
+    "    with requests.get(url_base + filename, stream=True) as r:\n",
+    "        r.raise_for_status()\n",
+    "        with open(os.path.join(dest_dir, filename), 'wb') as f:\n",
+    "            for chunk in r.iter_content(chunk_size=8192):\n",
+    "                f.write(chunk)\n",
+    "\n",
+    "# Download and save each NetCDF file\n",
+    "for drought_monitor_filename in drought_monitor_data_files:\n",
+    "    if not os.path.isfile(os.path.join(path_to_drought_monitor_data, drought_monitor_filename)):\n",
+    "        download_drought_monitor_data(url_of_drought_monitor_data, drought_monitor_filename, path_to_drought_monitor_data)"
    ]
   },
   {
@@ -85,8 +128,8 @@
     }
    ],
    "source": [
-    "#!ls /cvmfs/netcdftest.usq\n",
-    "!ls /srv/cvmfs/agrefedst0.usq.edu.au"
+    "for file in os.listdir(path_to_drought_monitor_data):\n",
+    "    print(file)"
    ]
   },
   {
@@ -127,18 +170,13 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "#file2read_1 = '/cvmfs/netcdftest.usq/cdi_1.nc'\n",
-    "file2read_1 = '/srv/cvmfs/agrefedst0.usq.edu.au/cdi_1.nc'\n",
-    "#file2read_2 = '/cvmfs/netcdftest.usq/cdi_3.nc'\n",
-    "file2read_2 = '/srv/cvmfs/agrefedst0.usq.edu.au/cdi_3.nc'\n",
-    "#file2read_3 = '/cvmfs/netcdftest.usq/cdi_6.nc'\n",
-    "file2read_3 = '/srv/cvmfs/agrefedst0.usq.edu.au/cdi_6.nc'\n",
-    "#file2read_4 = '/cvmfs/netcdftest.usq/cdi_9.nc'\n",
-    "file2read_4 = '/srv/cvmfs/agrefedst0.usq.edu.au/cdi_9.nc'\n",
-    "#file2read_5 = '/cvmfs/netcdftest.usq/cdi_12.nc'\n",
-    "file2read_5 = '/srv/cvmfs/agrefedst0.usq.edu.au/cdi_12.nc'\n",
-    "file2read_6 = '/srv/cvmfs/agrefedst0.usq.edu.au/cdi_24.nc'\n",
-    "file2read_7 = '/srv/cvmfs/agrefedst0.usq.edu.au/cdi_36.nc'"
+    "file2read_1 = os.path.join(path_to_drought_monitor_data, 'cdi_1.nc')\n",
+    "file2read_2 = os.path.join(path_to_drought_monitor_data, 'cdi_3.nc')\n",
+    "file2read_3 = os.path.join(path_to_drought_monitor_data, 'cdi_6.nc')\n",
+    "file2read_4 = os.path.join(path_to_drought_monitor_data, 'cdi_9.nc')\n",
+    "file2read_5 = os.path.join(path_to_drought_monitor_data, 'cdi_12.nc')\n",
+    "file2read_6 = os.path.join(path_to_drought_monitor_data, 'cdi_24.nc')\n",
+    "file2read_7 = os.path.join(path_to_drought_monitor_data, 'cdi_36.nc')"
    ]
   },
   {

--- a/info_value.ipynb
+++ b/info_value.ipynb
@@ -121,6 +121,7 @@
     "import plotly.express as px\n",
     "import pandas as pd\n",
     "import json\n",
+    "import os\n",
     "import cartopy.crs as ccrs\n",
     "import cartopy.feature as cfeature\n",
     "from cartopy.feature import ShapelyFeature\n",
@@ -2767,7 +2768,9 @@
    "outputs": [],
    "source": [
     "# Access the drought monitor data\n",
-    "CDI_file = 'cdi_1.nc'                     # Use this file for now but need to use the path to stratum 0 later\n",
+    "path_to_drought_monitor_data = os.path.join(os.sep, 'home', 'jovyan', 'drought_monitor_data')\n",
+    "\n",
+    "CDI_file = os.path.join(path_to_drought_monitor_data, 'cdi_1.nc')\n",
     "cdi_1 = netCDF4.Dataset(CDI_file)\n",
     "lats = cdi_1.variables['latitude']\n",
     "lons = cdi_1.variables['longitude']\n",


### PR DESCRIPTION
update notebook to:
- download Drought Monitor data from AgReFed cache server
- save data into local filesystem
- read NetCDF files from local filesystem
- Removed some references to UniSQ CVMFS servers